### PR TITLE
Fix automatic data update

### DIFF
--- a/src/main/java/com/adriansoftware/BankValueHistoryTracker.java
+++ b/src/main/java/com/adriansoftware/BankValueHistoryTracker.java
@@ -234,7 +234,7 @@ public class BankValueHistoryTracker
 		{
 			int currentBankTab = client.getVar(Varbits.CURRENT_BANK_TAB);
 			LocalDateTime lastEntry = getLastDataEntry(client.getUsername(), currentBankTab);
-			LocalDateTime nextUpdateTime = LocalDateTime.now().plusHours(config.getDefaultDatasetEntry());
+			LocalDateTime nextUpdateTime = lastEntry.plusHours(config.getDefaultDatasetEntry());
 
 			if (config.getOnlyManualEntries() && !force)
 			{


### PR DESCRIPTION
Currently it checks if the current time is X hours after the current time. Changed it to check against lastEntry instead.