### PR TITLE
Fix a runtime crash with `LocalDateTime` deserialization for Java 8.

### DIFF
--- a/src/main/java/com/adriansoftware/BankValueHistoryTracker.java
+++ b/src/main/java/com/adriansoftware/BankValueHistoryTracker.java
@@ -26,12 +26,18 @@ package com.adriansoftware;
 
 import com.google.common.collect.ImmutableList;
 import com.google.gson.Gson;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParseException;
 import com.google.inject.Provides;
 import java.io.File;
 import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.lang.reflect.Type;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -73,8 +79,13 @@ public class BankValueHistoryTracker
 
 	private static final File HISTORY_CACHE;
 	private static final Gson GSON =
-		RuneLiteAPI.GSON.newBuilder().registerTypeAdapter(BankValueHistoryContainer.class,
-			new BankValueHistoryDeserializer()).create();
+			RuneLiteAPI.GSON.newBuilder().registerTypeAdapter(BankValueHistoryContainer.class,
+					new BankValueHistoryDeserializer()).registerTypeAdapter(LocalDateTime.class, new JsonDeserializer<LocalDateTime>() {
+				@Override
+				public LocalDateTime deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
+					return LocalDateTime.parse(json.getAsString(), DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"));
+				}
+			}).create();
 	private static final String EXTENTION = ".json";
 
 	@Inject


### PR DESCRIPTION
With Java 8, the `LocalDateTime` cannot be deserialized directly with Gson.

The formatting here is a bit gnarly, but I deferred to the Intellij code formatting tool to linewrap it however it wanted.

Crash stacktrace:

```
[Client] ERROR net.runelite.client.callback.ClientThread - Exception in invoke
java.lang.AssertionError: AssertionError (GSON 2.8.5): gsoning private field class java.time.LocalDateTime.date
	at com.google.gson.Gson.toJson(Gson.java:708)
	at com.google.gson.Gson.toJson(Gson.java:683)
	at com.google.gson.Gson.toJson(Gson.java:658)
	at com.adriansoftware.BankValueHistoryTracker.add(BankValueHistoryTracker.java:116)
	at com.adriansoftware.BankValueHistoryTracker.lambda$addEntry$1(BankValueHistoryTracker.java:252)
	at net.runelite.client.callback.ClientThread.lambda$invokeLater$1(ClientThread.java:79)
	at net.runelite.client.callback.ClientThread.invoke(ClientThread.java:99)
	at net.runelite.client.callback.Hooks.tick(Hooks.java:193)
	at client.qr(client.java:28429)
	at client.ag(client.java)
	at aj.h(aj.java:368)
	at aj.run(aj.java:347)
	at java.base/java.lang.Thread.run(Thread.java:830)
Caused by: java.lang.AssertionError: gsoning private field class java.time.LocalDateTime.date
	at net.runelite.http.api.gson.IllegalReflectionExclusion.shouldSkipField(IllegalReflectionExclusion.java:61)
	at com.google.gson.internal.Excluder.excludeField(Excluder.java:184)
	at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory.excludeField(ReflectiveTypeAdapterFactory.java:69)
	at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory.excludeField(ReflectiveTypeAdapterFactory.java:65)
	at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory.getBoundFields(ReflectiveTypeAdapterFactory.java:154)
	at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory.create(ReflectiveTypeAdapterFactory.java:102)
	at com.google.gson.Gson.getAdapter(Gson.java:458)
	at com.google.gson.internal.bind.MapTypeAdapterFactory.getKeyAdapter(MapTypeAdapterFactory.java:142)
	at com.google.gson.internal.bind.MapTypeAdapterFactory.create(MapTypeAdapterFactory.java:125)
	at com.google.gson.Gson.getAdapter(Gson.java:458)
	at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory.createBoundField(ReflectiveTypeAdapterFactory.java:117)
	at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory.getBoundFields(ReflectiveTypeAdapterFactory.java:166)
	at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory.create(ReflectiveTypeAdapterFactory.java:102)
	at com.google.gson.Gson.getDelegateAdapter(Gson.java:541)
	at com.google.gson.internal.bind.TreeTypeAdapter.delegate(TreeTypeAdapter.java:89)
	at com.google.gson.internal.bind.TreeTypeAdapter.write(TreeTypeAdapter.java:74)
	at com.google.gson.Gson.toJson(Gson.java:704)
	... 12 more
Caused by: java.lang.AssertionError: gsoning private field class java.time.LocalDateTime.date
```