### PR TITLE
Fix gradle warning for `sourceCompatibility`.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,6 @@ dependencies {
 
 group = 'com.adriansoftware'
 version = '1.0-SNAPSHOT'
-sourceCompatibility = '1.8'
 
 tasks.withType(JavaCompile) {
 	options.encoding = 'UTF-8'


### PR DESCRIPTION
This was displaying a warning `Assignment is not used` for this field.

Truthfully IDK what this is for, but removing it still builds fine. And the warning went away.