### PR TITLE
Add `Xlint` deprecation warnings.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,4 +33,5 @@ sourceCompatibility = '1.8'
 
 tasks.withType(JavaCompile) {
 	options.encoding = 'UTF-8'
+	options.compilerArgs << "-Xlint:deprecation"
 }


### PR DESCRIPTION
Runelite is making some deprecated APIs blocking, so we should track these.