### PR TITLE
Fix the auto-entry behavior.

### DIFF
--- a/src/main/java/com/adriansoftware/BankHistoryPlugin.java
+++ b/src/main/java/com/adriansoftware/BankHistoryPlugin.java
@@ -149,15 +149,6 @@ public class BankHistoryPlugin extends Plugin
 	}
 
 	@Subscribe
-	public void onScriptCallbackEvent(ScriptCallbackEvent event)
-		{
-		if ("setBankTitle".equals(event.getEventName()))
-		{
-			tracker.addEntry();
-		}
-	}
-
-	@Subscribe
 	public void onWidgetLoaded(final WidgetLoaded event) throws InvocationTargetException, InterruptedException {
 		if (event.getGroupId() == WidgetID.BANK_GROUP_ID)
 		{
@@ -178,6 +169,7 @@ public class BankHistoryPlugin extends Plugin
 		if (event.getGroupId() == WidgetID.BANK_GROUP_ID) {
 			log.debug("onWidgetClosed: Bank closed");
 			bankHistoryPanel.setDatasetButton(false);
+			tracker.addEntry();
 		}
 	}
 


### PR DESCRIPTION
The onScriptEventCallback does not produce anything named `setBankTitle`. At least not for me. I couldn't find any good event to use, so instead just update whenever the user closes the bank. This is stable and more reliable.

Fixes https://github.com/AdrianLeeElder/runelite-bank-history-plugin/issues/9