### PR TITLE
Update verification-metadata.xml

### DIFF
--- a/gradle/verification-metadata.xml
+++ b/gradle/verification-metadata.xml
@@ -3,6 +3,10 @@
    <configuration>
       <verify-metadata>true</verify-metadata>
       <verify-signatures>false</verify-signatures>
+         <trust group="net.runelite"/>
+         <trust group="net.runelite.arn"/>
+         <trust group="org.lwjgl"/>
+         <trust group="com.google.protobuf"/>
    </configuration>
    <components>
       <component group="aopalliance" name="aopalliance" version="1.0">


### PR DESCRIPTION
Allow subsequent updates to runelite to pass checksum verification without manual input

Alternative to removing the file entirely which should allow it to pass runelites regulations