### PR TITLE
Change API calls from depreciated getUsername()

### DIFF
--- a/src/main/java/com/adriansoftware/BankHistoryPlugin.java
+++ b/src/main/java/com/adriansoftware/BankHistoryPlugin.java
@@ -77,7 +77,6 @@ public class BankHistoryPlugin extends Plugin
 	{
 		String username = this.tracker.getAvailableUsers().isEmpty() ? "" : this.tracker.getAvailableUsers().get(0);
 		loadPluginPanel(username);
-
 		clientToolbar.addNavigation(navButton);
 	}
 
@@ -117,7 +116,7 @@ public class BankHistoryPlugin extends Plugin
 		if (event.getGroupId() == InterfaceID.BANK)
 		{
 			log.trace("Player opened the bank");
-			SwingUtilities.invokeAndWait(() -> this.loadPluginPanel(client.getUsername()));
+			SwingUtilities.invokeAndWait(() -> this.loadPluginPanel(client.getLocalPlayer().getName()));
 			if (isHistoryPanelActive())
 			{
 				bankHistoryPanel.setDatasetButton(true);

--- a/src/main/java/com/adriansoftware/BankValueHistoryTracker.java
+++ b/src/main/java/com/adriansoftware/BankValueHistoryTracker.java
@@ -244,7 +244,7 @@ public class BankValueHistoryTracker
 		clientThread.invokeLater(() ->
 		{
 			int currentBankTab = client.getVarbitValue(Varbits.CURRENT_BANK_TAB);
-			LocalDateTime lastEntry = getLastDataEntry(client.getUsername(), currentBankTab);
+			LocalDateTime lastEntry = getLastDataEntry(client.getLocalPlayer().getName(), currentBankTab);
 			LocalDateTime nextUpdateTime = LocalDateTime.of(0, 1, 1, 0, 0);
 			if (lastEntry != null)
 			{
@@ -262,7 +262,7 @@ public class BankValueHistoryTracker
 			{
 				Item[] items = getBankTabItems();
 				if (items != null) {
-					BankValueHistoryTracker.this.add(client.getUsername(),
+					BankValueHistoryTracker.this.add(client.getLocalPlayer().getName(),
 						BankValue
 							.builder()
 							.tab(client.getVarbitValue(Varbits.CURRENT_BANK_TAB))


### PR DESCRIPTION
I've replaced all of the client.getUsername() calls with getLocalPlayer.getName(). This fixes the issue that exists when using the Jagex Launcher.

You may need to clear out/rename some of the json entries from the blank file name. Also, this returns a case-sensitive username, but I'm not sure if previously getUsername() returned all lowercase or not (if so I can update my changes).